### PR TITLE
Repaired VTKOutputObserver

### DIFF
--- a/limex_plugin.cpp
+++ b/limex_plugin.cpp
@@ -214,8 +214,8 @@ static void DomainAlgebra(Registry& reg, string grp)
 		reg.add_class_<T, typename T::base_type>(name, grp)
 			.template add_constructor<void (*)(const char*, SmartPtr<typename T::vtk_type>) >("")
 			.template add_constructor<void (*)(const char*, SmartPtr<typename T::vtk_type>, number) >("")
-			//.add_method("set_output_scales", &T::set_output_scales)
-			.add_method("close", &T::close)
+			.add_method("set_output_scales", &T::set_output_scales)
+			//.add_method("close", &T::close)
 			.set_construct_as_smart_pointer(true);
 		reg.add_class_to_group(name, "VTKOutputObserver", tag);
 	}


### PR DESCRIPTION
This should take care of issue #1.

The observer did not work any more in case the solution was to be printed only at specified time intervals. This was due to an change in the interface ITimeIntegratorObserver.
The VTKOutputObserver is now implemented as an observer statically attached to the stages
  start  finalize  end.
It can be attached using attach_observer() without specifying the individual stages, they are deduced automatically.

I took the liberty of re-enabling optional scaling of the solution prior to vtk export and removing the close-method (which is no longer necessary).
